### PR TITLE
Doesn't set default value to redis when just try read

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -3,6 +3,7 @@
 == 1.2.1 (1 Nov 2015)
 
 * Fixed use of #tap which caused issues with pipelined calls [Ross Kaffenberger]
+* Removed setnx on get some value with default option [Ilya Kamenko]
 
 == 1.2.0 (30 Apr 2015)
 

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -9,10 +9,6 @@ class Redis
     include Redis::Helpers::CoreCommands
 
     attr_reader :key, :options
-    def initialize(key, *args)
-      super(key, *args)
-      redis.setnx(key, marshal(@options[:default])) if !@options[:default].nil?
-    end
 
     def value=(val)
       allow_expiration do
@@ -26,7 +22,12 @@ class Redis
     alias_method :set, :value=
 
     def value
-      unmarshal redis.get(key)
+      value = unmarshal(redis.get(key))
+      if value.nil? && !@options[:default].nil?
+        @options[:default]
+      else
+        value
+      end
     end
     alias_method :get, :value
 


### PR DESCRIPTION
Why client trying set default value to redis if I just try read some value?
